### PR TITLE
copy to clipboard

### DIFF
--- a/yfi.sh
+++ b/yfi.sh
@@ -46,6 +46,7 @@ sed -i -e 's/^http:/https:/g' \
 select choice in \
         "Open in default browser" \
 	"Open in VLC" \
+	"Copy to Clipboard" \
 
 do
 case $choice in
@@ -55,7 +56,15 @@ case $choice in
         "Open in VLC")
         vlc $1;
         ;;
-        *)
+	"Copy to Clipboard")
+	cat /tmp/old_yturl.txt | xclip -selection c;
+	echo "the new URL"; 
+	tput setaf 6;
+	tput bold;
+	echo $(cat /tmp/old_yturl.txt); 
+	tput sgr0;
+	echo "has been copied to your clipboard";
+#        *)
             echo "What do you want to do?";
 
         esac


### PR DESCRIPTION
The added code copies the new url to clipboard. User can go to any other application and do Ctrl+V to paste.

Requires Xclip, which I don't think ships with most distros. Anyway. User should get a warning if they don't have it installed, right?

EDIT: Shite. No, user gets no warning. old unsafe url remains in clipboard.
